### PR TITLE
Initial addition of emails

### DIFF
--- a/serials.cabal
+++ b/serials.cabal
@@ -67,4 +67,7 @@ executable serials
     jwt,
     cookie,
     entropy
+    mandrill,
+    email-validate,
+    blaze-html
 

--- a/serials.cabal
+++ b/serials.cabal
@@ -66,8 +66,9 @@ executable serials
     random,
     jwt,
     cookie,
-    entropy
+    entropy,
     mandrill,
     email-validate,
+    blaze-markup,
     blaze-html
 

--- a/server/Serials/Api.hs
+++ b/server/Serials/Api.hs
@@ -48,6 +48,7 @@ import qualified Serials.Admin as Admin
 import Serials.Read.Test (proxyApp)
 
 import Serials.Route.Auth
+import Serials.Route.Invite
 import Serials.Route.UserSignup (UserSignup)
 import qualified Serials.Route.UserSignup as UserSignup
 
@@ -266,7 +267,7 @@ invitesServer h = list :<|> add :<|> find
   where
 
   add :: Email -> Handler ()
-  add e = liftIO $ Invite.addEmail h e
+  add e = liftIO $ invite h e
 
   list :: Handler [Invite]
   list = liftIO $ Invite.all h

--- a/server/Serials/Lib/Mail.hs
+++ b/server/Serials/Lib/Mail.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Serials.Lib.Mail where
+
+import Data.ByteString (ByteString)
+import Data.Text (Text)
+import Data.Maybe (fromJust)
+import Network.API.Mandrill
+import Text.Email.Validate (emailAddress)
+import Text.Blaze.Html (Html, toHtml, toMarkup)
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as A
+
+sendMail :: ByteString -> Text -> Html -> IO ()
+sendMail toEmail subj msg = runMandrill "MANDRILLTOKEN" $ do
+  let from = fromJust $ emailAddress "no-reply@serials.orbit.al"
+  let to = fromJust $ emailAddress toEmail
+  res <- sendEmail (newHtmlMessage from [to] subj msg)
+  case res of
+    MandrillSuccess k -> liftIO (print k)
+    MandrillFailure f -> liftIO (print f)
+
+-- consider just passing user in here so we can use what we want.
+-- just need to move things around so we don't get circular problems.
+welcomeEmail :: Text -> Html
+welcomeEmail name = do
+  H.h3 ("Hello " >> toHtml name >> ",")
+  H.p "Welcome to Serials. Serials aims to be a podcast-like experience for reading serial publications on the web."
+  H.p "Many excellent books and webcomics are being published openly on the web today. Most of those are published one chapter at a time. It's awesome that authors are self-publishing, but this format can make it hard to keep track of your progress."
+  H.p "Serials lets you subscribe to your favorite works, keep track of your progress, and receive notifications when new content is published"
+  H.hr
+  H.p $ do
+    "Have a suggestion? Want to be notified when we launch? Email us at "
+    H.a H.! A.href "mailto:serials@orbit.al" $ "serials@orbit.al"
+  H.hr

--- a/server/Serials/Lib/Mail.hs
+++ b/server/Serials/Lib/Mail.hs
@@ -1,30 +1,51 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Serials.Lib.Mail where
+module Serials.Lib.Mail (
+  sendWelcomeEmail
+  , sendInviteEmail
+) where
 
+import System.Environment
+import Data.Monoid ((<>))
 import Data.ByteString (ByteString)
-import Data.Text (Text)
+import Data.Text (Text, pack)
+import Data.Text.Encoding (encodeUtf8)
 import Data.Maybe (fromJust)
 import Network.API.Mandrill
 import Text.Email.Validate (emailAddress)
+import Text.Blaze (textValue)
 import Text.Blaze.Html (Html, toHtml, toMarkup)
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
-sendMail :: ByteString -> Text -> Html -> IO ()
-sendMail toEmail subj msg = runMandrill "MANDRILLTOKEN" $ do
-  let from = fromJust $ emailAddress "no-reply@serials.orbit.al"
-  let to = fromJust $ emailAddress toEmail
-  res <- sendEmail (newHtmlMessage from [to] subj msg)
-  case res of
-    MandrillSuccess k -> liftIO (print k)
-    MandrillFailure f -> liftIO (print f)
+import Serials.Model.User (User)
+import qualified Serials.Model.User as U
+import Serials.Model.Invite (Invite)
+import qualified Serials.Model.Invite as I
 
--- consider just passing user in here so we can use what we want.
--- just need to move things around so we don't get circular problems.
-welcomeEmail :: Text -> Html
-welcomeEmail name = do
-  H.h3 ("Hello " >> toHtml name >> ",")
+sendWelcomeEmail :: User -> IO ()
+sendWelcomeEmail u = sendMail (encodeUtf8 $ U.email u) "Welcome to Serials" (welcomeEmail u)
+
+sendInviteEmail :: Invite -> IO ()
+sendInviteEmail i = sendMail (encodeUtf8 $ I.email i) "Invite to join Serials" (inviteEmail i)
+
+sendMail :: ByteString -> Text -> Html -> IO ()
+sendMail toEmail subj msg = do
+  -- Should change this so we don't lookupEnv each time we send an email
+  apiKey <- (return . fmap pack) =<< lookupEnv "MANDRILL_API_KEY"
+  case apiKey of
+    Nothing -> print "You must 'export MANDRILL_API_KEY=\"YOURKEYGOESHERE\"' for sendMail to work"
+    Just a -> runMandrill a $ do
+      let from = fromJust $ emailAddress "no-reply@serials.orbit.al"
+      let to = fromJust $ emailAddress toEmail
+      res <- sendEmail (newHtmlMessage from [to] subj msg)
+      case res of
+        MandrillSuccess k -> liftIO (print k)
+        MandrillFailure f -> liftIO (print f)
+
+welcomeEmail :: User -> Html
+welcomeEmail u = do
+  H.h3 ("Hello " >> toHtml (U.firstName u) >> ",")
   H.p "Welcome to Serials. Serials aims to be a podcast-like experience for reading serial publications on the web."
   H.p "Many excellent books and webcomics are being published openly on the web today. Most of those are published one chapter at a time. It's awesome that authors are self-publishing, but this format can make it hard to keep track of your progress."
   H.p "Serials lets you subscribe to your favorite works, keep track of your progress, and receive notifications when new content is published"
@@ -33,3 +54,11 @@ welcomeEmail name = do
     "Have a suggestion? Want to be notified when we launch? Email us at "
     H.a H.! A.href "mailto:serials@orbit.al" $ "serials@orbit.al"
   H.hr
+
+inviteEmail :: Invite -> Html
+inviteEmail i = do
+  H.h3 "You have been invited to join Serials,"
+  H.p $ do
+    "Just need to click this link and finishing creating your account: "
+    H.a H.! A.href (textValue $ "http://localhost:3001/#/signup/" <> I.code i) $ "create account"
+

--- a/server/Serials/Model/Invite.hs
+++ b/server/Serials/Model/Invite.hs
@@ -13,6 +13,7 @@ import Data.Char (intToDigit, chr)
 import Data.Text (Text, toLower, unpack, pack)
 import Data.Text.Encoding
 import Data.Pool
+import Data.Maybe (fromJust)
 import Data.Monoid ((<>))
 
 import GHC.Generics
@@ -53,10 +54,11 @@ codeIndex     = Index codeIndexName
 
 table = R.table "invites"
 
-addEmail :: Pool RethinkDBHandle -> Email -> IO ()
+addEmail :: Pool RethinkDBHandle -> Email -> IO Invite
 addEmail h e = do
-    inv <- invite e
-    runPool h $ table # insert (toDatum $ inv) :: IO ()
+    i <- invite e
+    r <- runPool h $ table # ex insert [returnChanges] (toDatum $ i)
+    return . fromJust $ writeChangeNew r
 
 emailId :: Text -> Email
 emailId = toLower

--- a/server/Serials/Model/User.hs
+++ b/server/Serials/Model/User.hs
@@ -27,7 +27,6 @@ import Database.RethinkDB.NoClash hiding (table, Object, toJSON)
 
 import Serials.Model.Lib.Crud
 import Serials.Lib.JWT
-import Serials.Lib.Mail
 
 import Web.JWT (JWTClaimsSet)
 

--- a/server/Serials/Model/User.hs
+++ b/server/Serials/Model/User.hs
@@ -27,6 +27,7 @@ import Database.RethinkDB.NoClash hiding (table, Object, toJSON)
 
 import Serials.Model.Lib.Crud
 import Serials.Lib.JWT
+import Serials.Lib.Mail
 
 import Web.JWT (JWTClaimsSet)
 
@@ -79,7 +80,6 @@ insert h u = do
     r <- runPool h $ table # create u
     let user = u {id = generatedKey r}
     return $ user
-
 
 init :: Pool RethinkDBHandle -> IO ()
 init h = do

--- a/server/Serials/Route/Invite.hs
+++ b/server/Serials/Route/Invite.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Serials.Route.Invite where
+
+import Data.Pool
+import Database.RethinkDB.NoClash
+
+import Serials.Model.Invite
+import Serials.Lib.Mail
+
+invite :: Pool RethinkDBHandle -> Email -> IO ()
+invite h e = do
+  inv <- addEmail h e
+  sendInviteEmail inv
+  return ()
+

--- a/server/Serials/Route/UserSignup.hs
+++ b/server/Serials/Route/UserSignup.hs
@@ -21,6 +21,7 @@ import Database.RethinkDB.NoClash hiding (table)
 import qualified Serials.Model.User as User
 import Serials.Model.User (User)
 import qualified Serials.Model.Invite as Invite
+import Serials.Lib.Mail
 
 data UserSignup = UserSignup {
   firstName :: Text,
@@ -58,6 +59,7 @@ signup h u = do
             Just user -> do
               createdUser <- User.insert h user
               Invite.markUsed h (code u) (User.id createdUser)
+              sendWelcomeEmail createdUser
               return $ Right createdUser
 
 newUser :: UserSignup -> IO (Maybe User)


### PR DESCRIPTION
Feel free to make any changes you see fit. Fixes #25.
- Includes `inviteEmail`
- Includes `welcomeEmail`
- Note that you do need to `export MANDRILL_API_KEY="YOURKEYGOESHERE"`

[EDIT]
- default link value just use `ENV=production` on deploy
  Adds default link value. Added MailConfig. Might be overkill if we never need any other config stuff but feel free to modify to your liking.
